### PR TITLE
feat(bridge): show a pasteable bridge URL in General settings

### DIFF
--- a/packages/browser/bridge-browser/package.json
+++ b/packages/browser/bridge-browser/package.json
@@ -8,6 +8,14 @@
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-locale",
+        "@deepseek-ai/dsh-client-ui-slots",
+        "@deepseek-ai/dsh-client-ui-settings"
+      ],
+      "platform": "web"
     }
   },
   "type": "module",
@@ -26,6 +34,7 @@
       "types": "./lib/types/invariant.d.ts",
       "default": "./lib/invariant.js"
     },
+    "./client": "./lib/client.js",
     "./cordis.patch.yml": "./cordis.patch.yml",
     "./src/*": "./src/*",
     "./package.json": "./package.json"
@@ -34,6 +43,7 @@
     "lib/index.js",
     "lib/invariant.js",
     "lib/protocol.js",
+    "lib/client.js",
     "lib/types/**/*.d.ts",
     "cordis.patch.yml",
     "src"
@@ -42,12 +52,30 @@
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
     "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+    "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+    "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+    "@deepseek-ai/dsh-client-ui-slots": "^0.1.1-rc.1",
     "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
     "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
     "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
     "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
     "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-    "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+    "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+    "react": ">=18.2.0 <19"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-client-locale": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-client-ui-settings": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-client-ui-slots": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@deepseek-ai/schemastery": "^3.18.1",
@@ -56,7 +84,7 @@
   "scripts": {
     "test": "vitest run",
     "typecheck": "tsc -b --pretty false",
-    "build": "tsc -b --pretty false && tsdown"
+    "build": "tsc -b --pretty false && tsdown && cp src/client.js lib/client.js"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.1",

--- a/packages/browser/bridge-browser/src/bridge-url.ts
+++ b/packages/browser/bridge-browser/src/bridge-url.ts
@@ -1,0 +1,57 @@
+/**
+ * Resolve the browser-extension bridge WebSocket URL from the current page
+ * location or a discovery response. Shared by the settings row and tests.
+ * @module @yuxianglin/dsh-bridge-browser/src/bridge-url
+ */
+
+import { BRIDGE_CONFIG_PATH, BRIDGE_PATH } from './protocol.ts'
+
+/** Minimal Location fields needed to rebuild a loopback-friendly ws URL. */
+export interface BridgeLocationLike {
+  protocol: string
+  hostname: string
+  port: string
+  host: string
+}
+
+/**
+ * Build `ws(s)://…/ext/bridge` from the page that hosts the dsh web UI.
+ * Loopback hostnames are normalized to `127.0.0.1` so the address pastes cleanly
+ * into the Chrome extension settings.
+ */
+export function bridgeWsUrlFromLocation(
+  location: BridgeLocationLike,
+  bridgePath: string = BRIDGE_PATH,
+): string {
+  const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const hostname = location.hostname === 'localhost' ? '127.0.0.1' : location.hostname
+  const host = location.port === '' ? hostname : `${hostname}:${location.port}`
+  return `${wsProtocol}//${host}${bridgePath}`
+}
+
+/**
+ * Prefer the discovery endpoint; fall back to reconstructing from `location`.
+ * @param fetchImpl - injectable fetch (defaults to global fetch).
+ * @param location - page location used for fallback and relative discovery URL.
+ */
+export async function resolveBridgeWsUrl(
+  location: BridgeLocationLike & { origin?: string },
+  fetchImpl: typeof fetch = fetch,
+  bridgeConfigPath: string = BRIDGE_CONFIG_PATH,
+): Promise<string> {
+  const fallback = bridgeWsUrlFromLocation(location)
+  try {
+    const base = location.origin ?? `${location.protocol}//${location.host}`
+    const response = await fetchImpl(`${base}${bridgeConfigPath}`, {
+      signal: AbortSignal.timeout(1_500),
+    })
+    if (!response.ok) return fallback
+    const body = await response.json() as { wsUrl?: unknown }
+    if (typeof body.wsUrl === 'string' && (body.wsUrl.startsWith('ws://') || body.wsUrl.startsWith('wss://'))) {
+      return body.wsUrl
+    }
+  } catch {
+    // Discovery is best-effort: the settings row still shows the reconstructed URL.
+  }
+  return fallback
+}

--- a/packages/browser/bridge-browser/src/client.js
+++ b/packages/browser/bridge-browser/src/client.js
@@ -1,0 +1,180 @@
+/**
+ * Browser half of `@yuxianglin/dsh-bridge-browser`.
+ *
+ * When the host plugin is active, this client registers a General-settings row
+ * that shows the pasteable bridge WebSocket URL for the Chrome extension.
+ */
+window.__ModuleLoader__.load({
+  id: '@yuxianglin/dsh-bridge-browser',
+  factory: (require) => {
+    const module = { exports: {} }
+    const React = require('react')
+
+    const BRIDGE_PATH = '/ext/bridge'
+    const BRIDGE_CONFIG_PATH = '/ext/bridge-config'
+    const LOCALE_NS = 'bridge-browser'
+    const STYLE_ID = '@yuxianglin/dsh-bridge-browser/BridgeAddressRow'
+    const inject = ['slots', 'locale']
+
+    const dictionaries = {
+      zh: {
+        'bridgeAddress.title': '浏览器桥地址',
+        'bridgeAddress.help': '粘贴到 Chrome 扩展「桥地址」设置；本机一般无需 Token。',
+        'bridgeAddress.copy': '复制',
+        'bridgeAddress.copied': '已复制',
+        'bridgeAddress.loading': '正在读取…',
+        'bridgeAddress.unavailable': '暂时无法读取桥地址',
+      },
+      en: {
+        'bridgeAddress.title': 'Browser bridge address',
+        'bridgeAddress.help': 'Paste into the Chrome extension Bridge address setting. Loopback needs no token.',
+        'bridgeAddress.copy': 'Copy',
+        'bridgeAddress.copied': 'Copied',
+        'bridgeAddress.loading': 'Loading…',
+        'bridgeAddress.unavailable': 'Bridge address unavailable',
+      },
+    }
+
+    function bridgeWsUrlFromLocation(location) {
+      const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const hostname = location.hostname === 'localhost' ? '127.0.0.1' : location.hostname
+      const host = location.port === '' ? hostname : `${hostname}:${location.port}`
+      return `${wsProtocol}//${host}${BRIDGE_PATH}`
+    }
+
+    async function resolveBridgeWsUrl(location) {
+      const fallback = bridgeWsUrlFromLocation(location)
+      try {
+        const response = await fetch(`${location.origin}${BRIDGE_CONFIG_PATH}`, {
+          signal: AbortSignal.timeout(1_500),
+        })
+        if (!response.ok) return fallback
+        const body = await response.json()
+        if (typeof body?.wsUrl === 'string'
+          && (body.wsUrl.startsWith('ws://') || body.wsUrl.startsWith('wss://'))) {
+          return body.wsUrl
+        }
+      } catch {
+        // Fall through to the reconstructed URL.
+      }
+      return fallback
+    }
+
+    function installStyle() {
+      if (typeof document === 'undefined') return () => {}
+      if (document.querySelector(`style[data-plugin-css=${JSON.stringify(STYLE_ID)}]`) !== null) {
+        return () => {}
+      }
+      const style = document.createElement('style')
+      style.dataset.plugin = '@yuxianglin/dsh-bridge-browser'
+      style.dataset.pluginCss = STYLE_ID
+      style.textContent = [
+        '.dshBridgeAddressRow{border-bottom:1px solid var(--dsw-alias-border-l2);display:flex;flex-direction:column;gap:8px;padding:16px 0}',
+        '.dshBridgeAddressTitle{color:var(--dsw-alias-label-primary);font-size:14px;font-weight:400;line-height:22px}',
+        '.dshBridgeAddressHelp{color:var(--dsw-alias-label-tertiary);font-size:12px;font-weight:400;line-height:18px}',
+        '.dshBridgeAddressBody{display:flex;align-items:center;gap:8px;min-width:0}',
+        '.dshBridgeAddressValue{flex:1;min-width:0;margin:0;padding:8px 12px;border-radius:10px;background:var(--dsw-alias-bg-module-platform);color:var(--dsw-alias-label-primary);font:400 12px/18px ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;user-select:all;-webkit-user-select:all;overflow-x:auto;white-space:nowrap}',
+        '.dshBridgeAddressCopy{flex:none;height:32px;padding:0 12px;border:none;border-radius:16px;background:var(--dsw-alias-bg-module-platform);color:var(--dsw-alias-label-primary);font:inherit;font-size:12px;line-height:18px;cursor:pointer}',
+        '.dshBridgeAddressCopy:hover{background:var(--dsw-alias-interactive-bg-hover)}',
+        '.dshBridgeAddressCopy:disabled{cursor:default;opacity:0.6}',
+      ].join('')
+      document.head.append(style)
+      return () => style.remove()
+    }
+
+    function BridgeAddressRow({ t }) {
+      const [address, setAddress] = React.useState('')
+      const [status, setStatus] = React.useState('loading')
+      const [copied, setCopied] = React.useState(false)
+
+      React.useEffect(() => {
+        let cancelled = false
+        void resolveBridgeWsUrl(window.location).then((url) => {
+          if (cancelled) return
+          setAddress(url)
+          setStatus('ready')
+        }).catch(() => {
+          if (cancelled) return
+          setStatus('error')
+        })
+        return () => { cancelled = true }
+      }, [])
+
+      React.useEffect(() => {
+        if (!copied) return undefined
+        const timer = window.setTimeout(() => setCopied(false), 1_500)
+        return () => window.clearTimeout(timer)
+      }, [copied])
+
+      const onCopy = React.useCallback(async () => {
+        if (address === '') return
+        try {
+          await navigator.clipboard.writeText(address)
+          setCopied(true)
+        } catch {
+          const selection = window.getSelection()
+          const node = document.querySelector('.dshBridgeAddressValue')
+          if (selection !== null && node instanceof HTMLElement) {
+            const range = document.createRange()
+            range.selectNodeContents(node)
+            selection.removeAllRanges()
+            selection.addRange(range)
+          }
+        }
+      }, [address])
+
+      const value = status === 'loading'
+        ? t('bridgeAddress.loading')
+        : status === 'error'
+          ? t('bridgeAddress.unavailable')
+          : address
+
+      return React.createElement(
+        'div',
+        { className: 'dshBridgeAddressRow' },
+        React.createElement('div', { className: 'dshBridgeAddressTitle' }, t('bridgeAddress.title')),
+        React.createElement('p', { className: 'dshBridgeAddressHelp' }, t('bridgeAddress.help')),
+        React.createElement(
+          'div',
+          { className: 'dshBridgeAddressBody' },
+          React.createElement(
+            'code',
+            {
+              className: 'dshBridgeAddressValue',
+              title: address || undefined,
+            },
+            value,
+          ),
+          React.createElement(
+            'button',
+            {
+              type: 'button',
+              className: 'dshBridgeAddressCopy',
+              disabled: status !== 'ready' || address === '',
+              onClick: () => { void onCopy() },
+            },
+            copied ? t('bridgeAddress.copied') : t('bridgeAddress.copy'),
+          ),
+        ),
+      )
+    }
+
+    function apply(ctx) {
+      ctx.effect(() => installStyle(), 'bridge-browser: settings row styles')
+      ctx.effect(
+        () => ctx.locale.register(LOCALE_NS, dictionaries),
+        'bridge-browser: settings dictionaries',
+      )
+      ctx.slots.inject('settings.general.item', () => ctx.slots.register({
+        name: 'settings.general.item',
+        id: 'bridge-browser-address',
+        order: 100,
+        locale: LOCALE_NS,
+      }, BridgeAddressRow))
+    }
+
+    module.exports.apply = apply
+    module.exports.inject = inject
+    return module.exports
+  },
+})

--- a/packages/browser/bridge-browser/tests/bridge-url.spec.ts
+++ b/packages/browser/bridge-browser/tests/bridge-url.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { bridgeWsUrlFromLocation, resolveBridgeWsUrl } from '../src/bridge-url.ts'
+
+describe('bridgeWsUrlFromLocation', () => {
+  it('builds a loopback ws URL and normalizes localhost', () => {
+    expect(bridgeWsUrlFromLocation({
+      protocol: 'http:',
+      hostname: '127.0.0.1',
+      port: '63566',
+      host: '127.0.0.1:63566',
+    })).toBe('ws://127.0.0.1:63566/ext/bridge')
+
+    expect(bridgeWsUrlFromLocation({
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: '43189',
+      host: 'localhost:43189',
+    })).toBe('ws://127.0.0.1:43189/ext/bridge')
+  })
+
+  it('uses wss on https pages and omits the default port when absent', () => {
+    expect(bridgeWsUrlFromLocation({
+      protocol: 'https:',
+      hostname: 'example.com',
+      port: '',
+      host: 'example.com',
+    })).toBe('wss://example.com/ext/bridge')
+  })
+})
+
+describe('resolveBridgeWsUrl', () => {
+  it('prefers /ext/bridge-config when available', async () => {
+    const fetchImpl = vi.fn(async () => new Response(
+      JSON.stringify({ wsUrl: 'ws://127.0.0.1:43189/ext/bridge' }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ))
+    await expect(resolveBridgeWsUrl({
+      protocol: 'http:',
+      hostname: '127.0.0.1',
+      port: '9999',
+      host: '127.0.0.1:9999',
+      origin: 'http://127.0.0.1:9999',
+    }, fetchImpl as unknown as typeof fetch)).resolves.toBe('ws://127.0.0.1:43189/ext/bridge')
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:9999/ext/bridge-config',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('falls back to the page location when discovery fails', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('offline')
+    })
+    await expect(resolveBridgeWsUrl({
+      protocol: 'http:',
+      hostname: '127.0.0.1',
+      port: '63566',
+      host: '127.0.0.1:63566',
+      origin: 'http://127.0.0.1:63566',
+    }, fetchImpl as unknown as typeof fetch)).resolves.toBe('ws://127.0.0.1:63566/ext/bridge')
+  })
+})

--- a/packages/browser/bridge-browser/tsconfig.json
+++ b/packages/browser/bridge-browser/tsconfig.json
@@ -21,5 +21,5 @@
     "rootDir": "src",
     "outDir": "lib/types"
   },
-  "include": ["src"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Desktop often binds a random local web port, so the extension’s fixed-port auto-discovery misses the host.
- When the bridge plugin is loaded, show the live `ws://127.0.0.1:<port>/ext/bridge` address in Settings → General so users can copy it into the extension.
- Prefer `/ext/bridge-config` when available; fall back to reconstructing the URL from the current page location.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a General-settings row that discovers and displays the active browser bridge WebSocket URL for copying into the extension.
- Adds discovery-first URL resolution with a page-location fallback.
- Registers the bridge client with the locale and settings-slot infrastructure.
- Exports and packages the browser client module.
- Adds unit coverage for URL reconstruction and discovery fallback behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The client packaging, settings integration, discovery response handling, and tested fallback behavior form a coherent implementation, and the investigated edge cases were not shown to be reachable in a supported configuration.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/browser/bridge-browser/src/client.js | Registers the localized General-settings row, discovers the bridge address, provides copy behavior, and manages its component styling. |
| packages/browser/bridge-browser/src/bridge-url.ts | Implements discovery-first bridge URL resolution with a deterministic location-based fallback. |
| packages/browser/bridge-browser/package.json | Adds browser-client injection metadata, optional peer contracts, the client export, and packaging/build support. |
| packages/browser/bridge-browser/tests/bridge-url.spec.ts | Covers localhost normalization, secure protocol selection, successful discovery, and discovery failure fallback behavior. |
| packages/browser/bridge-browser/tsconfig.json | Limits TypeScript compilation to TypeScript sources so the handwritten client JavaScript is handled by the explicit copy step. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant S as General Settings
  participant C as Bridge Client
  participant H as Bridge Host
  participant E as Chrome Extension
  U->>S: Open General settings
  S->>C: Render bridge address row
  C->>H: GET /ext/bridge-config
  alt Discovery succeeds
    H-->>C: wsUrl for active port
  else Discovery unavailable
    C->>C: Reconstruct URL from page location
  end
  C-->>S: Display bridge URL
  U->>S: Copy address
  U->>E: Paste bridge address
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(bridge): show a pasteable bridge UR..."](https://github.com/lum1104/dsh-browser/commit/6b5119c01ad58d8d59c4c5fc011279b90a8bae16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59821288)</sub>

<!-- /greptile_comment -->