### PR TITLE
fix(bridge): use Host follow tip for session/page throughSeq

### DIFF
--- a/packages/browser/bridge-browser/src/remote-host-api.ts
+++ b/packages/browser/bridge-browser/src/remote-host-api.ts
@@ -52,6 +52,8 @@ interface InvokeTarget {
 }
 
 interface SessionSnapshot {
+  /** Inclusive Host log tip from session/follow; required for later session/page calls. */
+  readonly cursor: number
   readonly records: readonly unknown[]
   readonly hasMore: boolean
   readonly projections?: unknown
@@ -73,6 +75,8 @@ export function createRemoteHostApi(
 class RemoteHostApi implements BrowserHostApi {
   private readonly fetchHandler: ReturnType<HostConnectionLike['createSharedFetchHandler']>
   private readonly extensionSessions = new ExtensionSessionRegistry()
+  /** Last known session/follow tip per Session; drives session/page throughSeq. */
+  private readonly historyCursors = new Map<string, number>()
   private activeEvents: EventGeneration | undefined
 
   constructor(
@@ -122,6 +126,7 @@ class RemoteHostApi implements BrowserHostApi {
       this.gateway,
       this.sendRemoteEventResult.bind(this),
       this.extensionSessions,
+      this.noteHistoryCursor.bind(this),
       signal,
     )
     const previous = this.activeEvents
@@ -146,13 +151,60 @@ class RemoteHostApi implements BrowserHostApi {
     const sessionId = sessionIdOf(call.payload)
     if (sessionId === undefined) return badRequest('session.history requires a non-empty sessionId')
     try {
+      const beforeSeq = optionalNonNegativeInteger(call.payload, 'beforeSeq')
+      const maxMessages = optionalPositiveInteger(call.payload, 'maxMessages')
+      if (beforeSeq !== undefined) {
+        const throughSeq = await this.historyThroughSeq(sessionId, call.signal)
+        const page = await this.gateway.invoke({
+          namespace: 'session',
+          method: 'page',
+          args: {
+            request: {
+              address: { kind: 'session', sessionId },
+              throughSeq,
+              beforeSeq,
+              ...(maxMessages === undefined ? {} : { maxMessages }),
+            },
+          },
+          signal: call.signal,
+        })
+        return { ok: true, value: historyPageValue(page) }
+      }
+
       const snapshot = this.activeEvents === undefined
         ? await oneShotSessionSnapshot(this.gateway, sessionId, call.signal)
         : await this.activeEvents.openSessionHistory(sessionId, call.signal)
+      this.noteHistoryCursor(sessionId, snapshot.cursor)
       return { ok: true, value: historyValue(snapshot) }
     } catch (error: unknown) {
       return { ok: false, error: this.failure(error) }
     }
+  }
+
+  /**
+   * Resolve a Host-legal throughSeq for older history pages.
+   * Never invent Number.MAX_SAFE_INTEGER — session/page rejects tips past the log cursor.
+   */
+  private async historyThroughSeq(sessionId: string, signal: AbortSignal): Promise<number> {
+    const cached = this.historyCursors.get(sessionId)
+    if (cached !== undefined) return cached
+    const snapshot = this.activeEvents === undefined
+      ? await oneShotSessionSnapshot(this.gateway, sessionId, signal)
+      : await this.activeEvents.openSessionHistory(sessionId, signal)
+    this.noteHistoryCursor(sessionId, snapshot.cursor)
+    const throughSeq = this.historyCursors.get(sessionId)
+    if (throughSeq === undefined) {
+      throw new TypeError('session/follow snapshot did not provide a usable history cursor')
+    }
+    return throughSeq
+  }
+
+  private noteHistoryCursor(sessionId: string, cursor: number): void {
+    // Host session/page refuses throughSeq past the durable tip; MAX_SAFE_INTEGER is
+    // only a UI sentinel elsewhere and must never be forwarded as a page tip.
+    if (!Number.isSafeInteger(cursor) || cursor < -1 || cursor === Number.MAX_SAFE_INTEGER) return
+    const previous = this.historyCursors.get(sessionId)
+    if (previous === undefined || cursor > previous) this.historyCursors.set(sessionId, cursor)
   }
 
   private async workspaceList(call: HostRpcCall): Promise<HostRpcResult> {
@@ -260,6 +312,7 @@ class EventGeneration {
     private readonly gateway: TypertGatewayLike,
     private readonly sendResult: SendRemoteEventResult,
     private readonly extensionSessions: ExtensionSessionRegistry,
+    private readonly onHistoryCursor: (sessionId: string, cursor: number) => void,
     outerSignal: AbortSignal,
   ) {
     this.signal = AbortSignal.any([outerSignal, this.lifetime.signal])
@@ -334,8 +387,10 @@ class EventGeneration {
         signal.throwIfAborted()
         throw new Error('browser bridge Session follower was replaced while opening')
       }
+      this.onHistoryCursor(sessionId, first.value.cursor)
       this.track(this.pumpSessionEvents(sessionId, revision, iterator, signal))
       return {
+        cursor: first.value.cursor,
         records: first.value.records,
         hasMore: first.value.hasMore,
         ...(first.value.projections === undefined ? {} : { projections: first.value.projections }),
@@ -362,6 +417,8 @@ class EventGeneration {
         if (!isSessionEventEntry(next.value)) {
           throw new TypeError('session/follow emitted an invalid incremental frame')
         }
+        const seq = next.value.event.seq
+        if (typeof seq === 'number') this.onHistoryCursor(sessionId, seq)
         this.queue.push({
           rpcId: crypto.randomUUID(),
           method: 'session/event',
@@ -586,6 +643,7 @@ async function oneShotSessionSnapshot(
       throw new TypeError('session/follow did not begin with a snapshot')
     }
     return {
+      cursor: first.value.cursor,
       records: first.value.records,
       hasMore: first.value.hasMore,
       ...(first.value.projections === undefined ? {} : { projections: first.value.projections }),
@@ -605,6 +663,42 @@ function historyValue(snapshot: SessionSnapshot): Record<string, unknown> {
     hasMore: snapshot.hasMore,
     ...(snapshot.projections === undefined ? {} : { projections: snapshot.projections }),
   }
+}
+
+function historyPageValue(page: unknown): Record<string, unknown> {
+  if (!isRecord(page) || !Array.isArray(page.records) || typeof page.hasMore !== 'boolean') {
+    return { events: [], hasMore: false }
+  }
+  return historyValue({
+    cursor: -1,
+    records: page.records,
+    hasMore: page.hasMore,
+    ...(page.projections === undefined ? {} : { projections: page.projections }),
+  })
+}
+
+function optionalNonNegativeInteger(
+  payload: unknown,
+  key: string,
+): number | undefined {
+  if (!isRecord(payload) || !(key in payload) || payload[key] === undefined) return undefined
+  const value = payload[key]
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new TypeError(`${key} must be a non-negative safe integer`)
+  }
+  return value as number
+}
+
+function optionalPositiveInteger(
+  payload: unknown,
+  key: string,
+): number | undefined {
+  if (!isRecord(payload) || !(key in payload) || payload[key] === undefined) return undefined
+  const value = payload[key]
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new TypeError(`${key} must be a positive safe integer`)
+  }
+  return value as number
 }
 
 function historyRecordEvents(record: unknown): Record<string, unknown>[] {
@@ -735,12 +829,16 @@ function isWorkspaceBaseline(value: unknown): value is {
 
 function isSessionSnapshot(value: unknown): value is {
   readonly type: 'snapshot'
+  readonly cursor: number
   readonly records: readonly unknown[]
   readonly hasMore: boolean
   readonly projections?: unknown
 } {
   return isRecord(value)
     && value.type === 'snapshot'
+    && Number.isSafeInteger(value.cursor)
+    && (value.cursor as number) >= -1
+    && (value.cursor as number) !== Number.MAX_SAFE_INTEGER
     && Array.isArray(value.records)
     && typeof value.hasMore === 'boolean'
 }

--- a/packages/browser/bridge-browser/src/remote-host-api.ts
+++ b/packages/browser/bridge-browser/src/remote-host-api.ts
@@ -702,9 +702,18 @@ function optionalPositiveInteger(
 }
 
 function historyRecordEvents(record: unknown): Record<string, unknown>[] {
-  if (!isRecord(record) || !isRecord(record.event)) return []
+  if (!isRecord(record)
+    || (record.type !== 'event' && record.type !== 'chunks')
+    || !isRecord(record.event)) {
+    throw new TypeError('session history carried an invalid record')
+  }
   const event = record.event
-  if (!isChunkRowEvent(event)) return [event]
+  if (!isChunkRowEvent(event)) {
+    if (record.type === 'chunks') {
+      throw new TypeError('session history chunks record carried a non-chunk event')
+    }
+    return [event]
+  }
 
   const data = event.data
   const members = event.type === 'chunkrow/tool-call-chunks' ? data.args : data.texts

--- a/packages/browser/bridge-browser/src/remote-host-api.ts
+++ b/packages/browser/bridge-browser/src/remote-host-api.ts
@@ -667,7 +667,7 @@ function historyValue(snapshot: SessionSnapshot): Record<string, unknown> {
 
 function historyPageValue(page: unknown): Record<string, unknown> {
   if (!isRecord(page) || !Array.isArray(page.records) || typeof page.hasMore !== 'boolean') {
-    return { events: [], hasMore: false }
+    throw new TypeError('session/page returned an invalid history page')
   }
   return historyValue({
     cursor: -1,

--- a/packages/browser/bridge-browser/src/remote-host-api.ts
+++ b/packages/browser/bridge-browser/src/remote-host-api.ts
@@ -150,9 +150,15 @@ class RemoteHostApi implements BrowserHostApi {
   private async sessionHistory(call: HostRpcCall): Promise<HostRpcResult> {
     const sessionId = sessionIdOf(call.payload)
     if (sessionId === undefined) return badRequest('session.history requires a non-empty sessionId')
+    let beforeSeq: number | undefined
+    let maxMessages: number | undefined
     try {
-      const beforeSeq = optionalNonNegativeInteger(call.payload, 'beforeSeq')
-      const maxMessages = optionalPositiveInteger(call.payload, 'maxMessages')
+      beforeSeq = optionalNonNegativeInteger(call.payload, 'beforeSeq')
+      maxMessages = optionalPositiveInteger(call.payload, 'maxMessages')
+    } catch (error: unknown) {
+      return badRequest(error instanceof Error ? error.message : 'session.history pagination is invalid')
+    }
+    try {
       if (beforeSeq !== undefined) {
         const throughSeq = await this.historyThroughSeq(sessionId, call.signal)
         const page = await this.gateway.invoke({
@@ -172,8 +178,8 @@ class RemoteHostApi implements BrowserHostApi {
       }
 
       const snapshot = this.activeEvents === undefined
-        ? await oneShotSessionSnapshot(this.gateway, sessionId, call.signal)
-        : await this.activeEvents.openSessionHistory(sessionId, call.signal)
+        ? await oneShotSessionSnapshot(this.gateway, sessionId, call.signal, maxMessages)
+        : await this.activeEvents.openSessionHistory(sessionId, call.signal, maxMessages)
       this.noteHistoryCursor(sessionId, snapshot.cursor)
       return { ok: true, value: historyValue(snapshot) }
     } catch (error: unknown) {
@@ -326,8 +332,12 @@ class EventGeneration {
     return this.queue.iterate(this.signal)
   }
 
-  async openSessionHistory(sessionId: string, callSignal: AbortSignal): Promise<SessionSnapshot> {
-    return this.openSessionFollow(sessionId, callSignal)
+  async openSessionHistory(
+    sessionId: string,
+    callSignal: AbortSignal,
+    maxMessages?: number,
+  ): Promise<SessionSnapshot> {
+    return this.openSessionFollow(sessionId, callSignal, maxMessages)
   }
 
   async ensureSessionFollow(sessionId: string, callSignal: AbortSignal): Promise<void> {
@@ -363,6 +373,7 @@ class EventGeneration {
   private async openSessionFollow(
     sessionId: string,
     callSignal: AbortSignal,
+    maxMessages?: number,
   ): Promise<SessionSnapshot> {
     const revision = ++this.followRevision
     this.followAbort?.abort(new Error('browser bridge Session follower replaced'))
@@ -373,7 +384,14 @@ class EventGeneration {
     try {
       const source = await this.gateway.wireStream.open(
         'session/follow',
-        { args: { request: { address: { kind: 'session', sessionId } } } },
+        {
+          args: {
+            request: {
+              address: { kind: 'session', sessionId },
+              ...(maxMessages === undefined ? {} : { maxMessages }),
+            },
+          },
+        },
         signal,
       )
       const iterator = source[Symbol.asyncIterator]()
@@ -634,12 +652,20 @@ async function oneShotSessionSnapshot(
   gateway: TypertGatewayLike,
   sessionId: string,
   outerSignal: AbortSignal,
+  maxMessages?: number,
 ): Promise<SessionSnapshot> {
   const controller = new AbortController()
   const signal = AbortSignal.any([outerSignal, controller.signal])
   const source = await gateway.wireStream.open(
     'session/follow',
-    { args: { request: { address: { kind: 'session', sessionId } } } },
+    {
+      args: {
+        request: {
+          address: { kind: 'session', sessionId },
+          ...(maxMessages === undefined ? {} : { maxMessages }),
+        },
+      },
+    },
     signal,
   )
   const iterator = source[Symbol.asyncIterator]()
@@ -689,7 +715,7 @@ function optionalNonNegativeInteger(
 ): number | undefined {
   if (!isRecord(payload) || !(key in payload) || payload[key] === undefined) return undefined
   const value = payload[key]
-  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+  if (!Number.isSafeInteger(value) || (value as number) < 0 || Object.is(value, -0)) {
     throw new TypeError(`${key} must be a non-negative safe integer`)
   }
   return value as number

--- a/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
+++ b/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
@@ -229,6 +229,37 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
     expect(pageArgs.request.throughSeq).not.toBe(Number.MAX_SAFE_INTEGER)
   })
 
+  it('fails closed when session/page returns a malformed history page', async () => {
+    const { api } = harness({
+      invoke: async ({ namespace, method }) => {
+        if (`${namespace}/${method}` !== 'session/page') throw new Error(`${namespace}/${method}`)
+        return { records: 'not-an-array' }
+      },
+      open: async (endpoint) => {
+        if (endpoint === 'session/follow') {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: 'snapshot', cursor: 5, records: [], hasMore: false }
+            },
+          }
+        }
+        throw new Error(endpoint)
+      },
+    })
+
+    await expect(api.call(call('session.history', {
+      sessionId: 'session-1',
+      beforeSeq: 3,
+    }))).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'internal',
+        message: 'session/page returned an invalid history page',
+        details: {},
+      },
+    })
+  })
+
   it('reads workspace.list from the workspace/follow baseline', async () => {
     const { api, open } = harness({
       open: async (endpoint) => ({

--- a/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
+++ b/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
@@ -105,6 +105,7 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
             async *[Symbol.asyncIterator]() {
               yield {
                 type: 'snapshot',
+                cursor: 3,
                 records: [
                   { type: 'event', event: { type: 'user/message', seq: 0, time: 1, data: {} } },
                   {
@@ -179,6 +180,55 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
     await events.return?.()
   })
 
+  it('pages older history with a Host-legal throughSeq, never MAX_SAFE_INTEGER', async () => {
+    const { api, invoke, open } = harness({
+      invoke: async ({ namespace, method, args }) => {
+        if (`${namespace}/${method}` !== 'session/page') throw new Error(`${namespace}/${method}`)
+        expect(args).toEqual({
+          request: {
+            address: { kind: 'session', sessionId: 'session-1' },
+            throughSeq: 42,
+            beforeSeq: 10,
+            maxMessages: 20,
+          },
+        })
+        return {
+          records: [{ type: 'event', event: { type: 'user/message', seq: 9, time: 1, data: {} } }],
+          hasMore: true,
+        }
+      },
+      open: async (endpoint) => {
+        if (endpoint === 'session/follow') {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: 'snapshot', cursor: 42, records: [], hasMore: false }
+            },
+          }
+        }
+        throw new Error(endpoint)
+      },
+    })
+
+    await expect(api.call(call('session.history', {
+      sessionId: 'session-1',
+      beforeSeq: 10,
+      maxMessages: 20,
+    }))).resolves.toEqual({
+      ok: true,
+      value: {
+        events: [{ event: { type: 'user/message', seq: 9, time: 1, data: {} } }],
+        hasMore: true,
+      },
+    })
+    expect(open).toHaveBeenCalledWith('session/follow', {
+      args: { request: { address: { kind: 'session', sessionId: 'session-1' } } },
+    }, expect.any(AbortSignal))
+    expect(invoke).toHaveBeenCalledOnce()
+    const pageArgs = invoke.mock.calls[0]?.[0]?.args as { request: { throughSeq: number } }
+    expect(pageArgs.request.throughSeq).toBe(42)
+    expect(pageArgs.request.throughSeq).not.toBe(Number.MAX_SAFE_INTEGER)
+  })
+
   it('reads workspace.list from the workspace/follow baseline', async () => {
     const { api, open } = harness({
       open: async (endpoint) => ({
@@ -204,7 +254,7 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
         if (endpoint === 'session/follow') {
           return {
             async *[Symbol.asyncIterator]() {
-              yield { type: 'snapshot', records: [], hasMore: false }
+              yield { type: 'snapshot', cursor: -1, records: [], hasMore: false }
               await abortWait(signal)
             },
           }
@@ -325,7 +375,7 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
         if (endpoint === 'session/follow') {
           return {
             async *[Symbol.asyncIterator]() {
-              yield { type: 'snapshot', records: [], hasMore: false }
+              yield { type: 'snapshot', cursor: -1, records: [], hasMore: false }
               await abortWait(signal)
             },
           }

--- a/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
+++ b/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
@@ -134,7 +134,10 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
     const live = events.next()
     await vi.waitFor(() => { expect(open).toHaveBeenCalledWith('$events', { args: {} }, expect.any(AbortSignal)) })
 
-    await expect(api.call(call('session.history', { sessionId: 'session-1' }))).resolves.toEqual({
+    await expect(api.call(call('session.history', {
+      sessionId: 'session-1',
+      maxMessages: 2,
+    }))).resolves.toEqual({
       ok: true,
       value: {
         events: [
@@ -174,10 +177,65 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
       }),
     })
     expect(open).toHaveBeenCalledWith('session/follow', {
-      args: { request: { address: { kind: 'session', sessionId: 'session-1' } } },
+      args: {
+        request: {
+          address: { kind: 'session', sessionId: 'session-1' },
+          maxMessages: 2,
+        },
+      },
     }, expect.any(AbortSignal))
     abort.abort()
     await events.return?.()
+  })
+
+  it('forwards tail-page size through a one-shot session/follow snapshot', async () => {
+    const { api, open } = harness({
+      open: async (endpoint) => {
+        if (endpoint !== 'session/follow') throw new Error(endpoint)
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'snapshot', cursor: -1, records: [], hasMore: false }
+          },
+        }
+      },
+    })
+
+    await expect(api.call(call('session.history', {
+      sessionId: 'session-one-shot',
+      maxMessages: 12,
+    }))).resolves.toEqual({
+      ok: true,
+      value: { events: [], hasMore: false },
+    })
+    expect(open).toHaveBeenCalledWith('session/follow', {
+      args: {
+        request: {
+          address: { kind: 'session', sessionId: 'session-one-shot' },
+          maxMessages: 12,
+        },
+      },
+    }, expect.any(AbortSignal))
+  })
+
+  it('rejects invalid history pagination before calling the Host', async () => {
+    const { api, invoke, open } = harness()
+
+    await expect(api.call(call('session.history', {
+      sessionId: 'session-1',
+      beforeSeq: -1,
+    }))).resolves.toEqual({
+      ok: false,
+      error: { code: 'bad-request', message: 'beforeSeq must be a non-negative safe integer', details: {} },
+    })
+    await expect(api.call(call('session.history', {
+      sessionId: 'session-1',
+      maxMessages: 0,
+    }))).resolves.toEqual({
+      ok: false,
+      error: { code: 'bad-request', message: 'maxMessages must be a positive safe integer', details: {} },
+    })
+    expect(open).not.toHaveBeenCalled()
+    expect(invoke).not.toHaveBeenCalled()
   })
 
   it('pages older history with a Host-legal throughSeq, never MAX_SAFE_INTEGER', async () => {

--- a/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
+++ b/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
@@ -260,6 +260,43 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
     })
   })
 
+  it('fails closed when session/page records omit a usable event envelope', async () => {
+    const { api } = harness({
+      invoke: async ({ namespace, method }) => {
+        if (`${namespace}/${method}` !== 'session/page') throw new Error(`${namespace}/${method}`)
+        return {
+          records: [
+            { type: 'event', event: { type: 'user/message', seq: 1, time: 1, data: {} } },
+            { type: 'event' },
+          ],
+          hasMore: false,
+        }
+      },
+      open: async (endpoint) => {
+        if (endpoint === 'session/follow') {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: 'snapshot', cursor: 5, records: [], hasMore: false }
+            },
+          }
+        }
+        throw new Error(endpoint)
+      },
+    })
+
+    await expect(api.call(call('session.history', {
+      sessionId: 'session-1',
+      beforeSeq: 3,
+    }))).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'internal',
+        message: 'session history carried an invalid record',
+        details: {},
+      },
+    })
+  })
+
   it('reads workspace.list from the workspace/follow baseline', async () => {
     const { api, open } = harness({
       open: async (endpoint) => ({


### PR DESCRIPTION
## Summary
- Cache the real `session/follow` tip and use it as `throughSeq` for `session/page`
- Never invent `Number.MAX_SAFE_INTEGER`, which Host rejects as past the log cursor
- Cover older-history paging in `remote-host-api` tests







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Host-tip-aware older-history paging and introduces a controlled `browser_open_tab` flow.
- Caches validated `session/follow` cursors and forwards them as `session/page.throughSeq`.
- Validates malformed history pages and records instead of returning successful incomplete results.
- Adds open-tab authorization, affinity rebinding, navigation readiness handling, documentation, and tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/browser/bridge-browser/src/remote-host-api.ts | Uses validated Host follow cursors for older-history paging and now fails closed on the malformed page and record shapes reported previously. |
| packages/browser/bridge-browser/tests/remote-host-api.spec.ts | Covers cursor reuse, paging requests, pagination validation, and malformed history responses. |
| extensions/dsh-browser/src/background/tools.ts | Adds HTTP(S)-restricted new-tab creation with authorization, cancellation cleanup, affinity binding, and optional snapshot capture. |
| extensions/dsh-browser/src/background/index.ts | Routes open-tab calls through the dedicated window-resolution and affinity-rebinding path. |
| extensions/dsh-browser/src/background/navigation.ts | Prevents a new Firefox tab's initial about:blank document from satisfying destination readiness. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Bridge as RemoteHostApi
  participant Follow as session/follow
  participant Page as session/page
  Client->>Bridge: session.history(sessionId)
  Bridge->>Follow: Open snapshot stream
  Follow-->>Bridge: snapshot(cursor, records, hasMore)
  Bridge-->>Client: Current history
  Client->>Bridge: session.history(beforeSeq)
  Bridge->>Page: "request(throughSeq=cursor, beforeSeq)"
  Page-->>Bridge: records, hasMore
  Bridge-->>Client: Older history page
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(bridge): preserve session history pa..."](https://github.com/lum1104/dsh-browser/commit/e6fe9965e7de13cc944ea9583704b8ca06ab2d8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59881549)</sub>

<!-- /greptile_comment -->