### PR TITLE
chore: bump project version to 0.1.4

### DIFF
--- a/extensions/dsh-browser/manifest.firefox.json
+++ b/extensions/dsh-browser/manifest.firefox.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "browser_specific_settings": {
     "gecko": {
       "id": "dsh-browser@lum1104.github.io",

--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "minimum_chrome_version": "116",
   "permissions": [
     "sidePanel",

--- a/extensions/dsh-browser/package.json
+++ b/extensions/dsh-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-browser-extension",
   "description": "Chrome and Firefox MV3 extension: sidebar chat with a local dsh instance and text-only read/operate of a user-controlled tab through the dsh browser bridge",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "Yuxiang Lin",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-browser",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Standalone dsh browser bridge and controlled-tab Chrome/Firefox extension workspace",
   "author": "Yuxiang Lin",
   "license": "MIT",

--- a/packages/browser/bridge-browser/package.json
+++ b/packages/browser/bridge-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yuxianglin/dsh-bridge-browser",
   "description": "Bridge plugin: token-authenticated WebSocket carrier for the browser extension plus text-only browser_* tools that drive the user's Chrome via that extension",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Yuxiang Lin",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## 概述 / Summary

按现有版本惯例将所有项目自有版本递增一个 patch，不创建 tag 或 GitHub Release。

## 改动内容 / Changes

- 根 package、扩展 package、Chrome/Firefox manifest：`0.1.3 → 0.1.4`。
- bridge package：`0.0.4 → 0.0.5`。

## 测试 / Testing

- `pnpm install --frozen-lockfile` 通过，锁文件无变化。
- `pnpm run build` 与 Firefox 构建通过。
- 检查两种构建产物的 manifest，版本均为 `0.1.4`。
- `git diff --check` 通过；仅修改 5 个版本字段。


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62971344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The version fields are internally consistent, and the PR appears safe to merge.

<h3>Summary</h3>

- Keeps the Chrome and Firefox manifest versions aligned.
- Keeps root and extension package metadata aligned.
- Follows the repository’s established patch-release pattern without requiring a lockfile update.

<sub>Reviews (1) · Last reviewed commit: ["chore: bump package versions by one patc..."](https://github.com/lum1104/dsh-browser/commit/429fa678a1c211b12ac0880a557f098fd30f478b)</sub>

<!-- /greptile_comment -->